### PR TITLE
Fixed damageTaken stat displaying a 99 occasionally

### DIFF
--- a/client/src/ui/ui.ts
+++ b/client/src/ui/ui.ts
@@ -1763,10 +1763,12 @@ export class UiManager {
         for (const k in displayStats) {
             if (displayStats.hasOwnProperty(k)) {
                 const text = displayStats[k as keyof typeof displayStats];
-                const stat =
+                let stat =
                     k == "timeAlive"
                         ? humanizeTime(stats[k])
                         : stats[k as keyof typeof displayStats];
+                if (typeof stat == "number" && k == "damageTaken") stat = Math.max(stat, 100);
+
                 const html = `<tr><td class="ui-spectate-stats-category">${text}</td><td class="ui-spectate-stats-value">${stat}</td></tr>`;
                 this.spectateModeStatsData.append(html);
             }


### PR DESCRIPTION
Math.max() picks the of greater value of the 2 provided, which means if the damage taken is less than 100, it will return 100. On the other hand, if the player heals and has more than 100 damage taken, then that value will be returned.