### PR TITLE
Remove extra ammo when firepower removed

### DIFF
--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -1052,7 +1052,12 @@ export class Player extends BaseGameObject {
         } else if (type === "fabricate") {
             this.fabricateRefillTicker = 0;
         } else if (type === "firepower") {
-            this.weaponManager.reload();
+            const originalIndex = this.weaponManager.curWeapIdx;
+            [0, 1].forEach((weapIndx) => {
+                this.weaponManager.setCurWeapIndex(weapIndx);
+                this.weaponManager.reload();
+            })
+            this.weaponManager.setCurWeapIndex(originalIndex);
         }
 
         this.recalculateScale();

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -1051,6 +1051,8 @@ export class Player extends BaseGameObject {
             }
         } else if (type === "fabricate") {
             this.fabricateRefillTicker = 0;
+        } else if (type === "firepower") {
+            this.weaponManager.reload();
         }
 
         this.recalculateScale();

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -1052,12 +1052,8 @@ export class Player extends BaseGameObject {
         } else if (type === "fabricate") {
             this.fabricateRefillTicker = 0;
         } else if (type === "firepower") {
-            const originalIndex = this.weaponManager.curWeapIdx;
-            [0, 1].forEach((weapIndx) => {
-                this.weaponManager.setCurWeapIndex(weapIndx);
-                this.weaponManager.reload();
-            })
-            this.weaponManager.setCurWeapIndex(originalIndex);
+            this.weaponManager.reload(GameConfig.WeaponSlot.Primary);
+            this.weaponManager.reload(GameConfig.WeaponSlot.Secondary);
         }
 
         this.recalculateScale();

--- a/server/src/game/weaponManager.ts
+++ b/server/src/game/weaponManager.ts
@@ -452,11 +452,7 @@ export class WeaponManager {
         }
 
         if (this.isInfinite(weaponDef)) {
-            weapon.ammo += math.clamp(
-                amountToReload,
-                0,
-                spaceLeft,
-            );
+            weapon.ammo += math.clamp(amountToReload, 0, spaceLeft);
         } else if (inv[weaponDef.ammo] < spaceLeft) {
             // 27/30, inv = 2
             if (trueAmmoStats.trueMaxClip != amountToReload) {
@@ -470,11 +466,7 @@ export class WeaponManager {
             }
         } else {
             // 27/30, inv = 100
-            weapon.ammo += math.clamp(
-                amountToReload,
-                0,
-                spaceLeft,
-            );
+            weapon.ammo += math.clamp(amountToReload, 0, spaceLeft);
             inv[weaponDef.ammo] -= math.clamp(amountToReload, 0, spaceLeft);
         }
 
@@ -483,10 +475,7 @@ export class WeaponManager {
             inv[weaponDef.ammo] == 0 && !this.isInfinite(weaponDef)
                 ? weapon.ammo
                 : trueAmmoStats.trueMaxClip;
-        if (
-            trueAmmoStats.trueMaxClip != amountToReload &&
-            weapon.ammo != realMaxClip
-        ) {
+        if (trueAmmoStats.trueMaxClip != amountToReload && weapon.ammo != realMaxClip) {
             this.player.reloadAgain = true;
         }
 

--- a/server/src/game/weaponManager.ts
+++ b/server/src/game/weaponManager.ts
@@ -437,10 +437,11 @@ export class WeaponManager {
     /**
      * called when reload action completed, actually updates all state variables
      */
-    reload(): void {
-        const weaponDef = GameObjectDefs[this.activeWeapon] as GunDef;
+    reload(curWeapIdx = this.curWeapIdx): void {
+        const weapon = this.weapons[curWeapIdx];
+        const weaponDef = GameObjectDefs[weapon.type] as GunDef;
         const trueAmmoStats = this.getTrueAmmoStats(weaponDef);
-        const activeWeaponAmmo = this.weapons[this.curWeapIdx].ammo;
+        const activeWeaponAmmo = weapon.ammo;
         const spaceLeft = trueAmmoStats.trueMaxClip - activeWeaponAmmo; // if gun is 27/30 ammo, spaceLeft = 3
 
         const inv = this.player.inventory;
@@ -451,7 +452,7 @@ export class WeaponManager {
         }
 
         if (this.isInfinite(weaponDef)) {
-            this.weapons[this.curWeapIdx].ammo += math.clamp(
+            weapon.ammo += math.clamp(
                 amountToReload,
                 0,
                 spaceLeft,
@@ -460,16 +461,16 @@ export class WeaponManager {
             // 27/30, inv = 2
             if (trueAmmoStats.trueMaxClip != amountToReload) {
                 // m870, mosin, spas: only refill by one bullet at a time
-                this.weapons[this.curWeapIdx].ammo++;
+                weapon.ammo++;
                 inv[weaponDef.ammo]--;
             } else {
                 // mp5, sv98, ak47: refill to as much as you have left in your inventory
-                this.weapons[this.curWeapIdx].ammo += inv[weaponDef.ammo];
+                weapon.ammo += inv[weaponDef.ammo];
                 inv[weaponDef.ammo] = 0;
             }
         } else {
             // 27/30, inv = 100
-            this.weapons[this.curWeapIdx].ammo += math.clamp(
+            weapon.ammo += math.clamp(
                 amountToReload,
                 0,
                 spaceLeft,
@@ -480,11 +481,11 @@ export class WeaponManager {
         // if you have an m870 with 2 ammo loaded and 0 ammo left in your inventory, your actual max clip is just 2 since you cant load anymore ammo
         const realMaxClip =
             inv[weaponDef.ammo] == 0 && !this.isInfinite(weaponDef)
-                ? this.weapons[this.curWeapIdx].ammo
+                ? weapon.ammo
                 : trueAmmoStats.trueMaxClip;
         if (
             trueAmmoStats.trueMaxClip != amountToReload &&
-            this.weapons[this.curWeapIdx].ammo != realMaxClip
+            weapon.ammo != realMaxClip
         ) {
             this.player.reloadAgain = true;
         }


### PR DESCRIPTION
Runs reload logic when firepower perk is removed from the player. This removes extra ammo that was in the gun because of the firepower perk and puts it back in the inventory.
Fixes #141 