### PR TITLE
Self revive bug fix

### DIFF
--- a/client/src/ui/ui2.ts
+++ b/client/src/ui/ui2.ts
@@ -1617,7 +1617,7 @@ export class UiManager2 {
                 if (
                     object &&
                     player &&
-                    object == player &&
+                    (object == player || player.downed) &&
                     player.m_hasPerk("self_revive")
                 ) {
                     return this.localization.translate("game-revive-self");

--- a/server/src/game/gameModeManager.ts
+++ b/server/src/game/gameModeManager.ts
@@ -315,7 +315,7 @@ export class GameModeManager {
 
                         player.kill(params);
                         // special case that only happens when the player has self_revive since the teammates wouldnt have previously been finished off
-                        if (group.checkAllDowned(player)) {
+                        if (group.checkAllDowned(player) && !group.checkSelfRevive()) { // don't kill teammates if any one has self revive
                             group.killAllTeammates();
                         }
                         return;

--- a/server/src/game/group.ts
+++ b/server/src/game/group.ts
@@ -107,6 +107,21 @@ export class Group {
         }
     }
 
+
+    /**
+     * checks if any players in the group have the self revive perk
+     * @returns true if any players in the group have the self revive perk
+     */
+    checkSelfRevive() {
+        const alivePlayers = this.getAlivePlayers();
+        for (const p of alivePlayers) {
+            if (p.hasPerk("self_revive")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     checkPlayers(): void {
         this.livingPlayers = this.players.filter((p) => !p.dead);
         this.allDeadOrDisconnected = this.players.every((p) => p.dead || p.disconnected);

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -1051,6 +1051,8 @@ export class Player extends BaseGameObject {
             }
         } else if (type === "fabricate") {
             this.fabricateRefillTicker = 0;
+        } else if (type === "firepower") {
+            this.weaponManager.reload();
         }
 
         this.recalculateScale();


### PR DESCRIPTION
Fixes [bug opened on Discord](https://discord.com/channels/1278403395614408725/1359887607298789656). When the final teammate is downed, the whole team is killed even if one of the teammates has revivify. This kills the player currently reviving themselves.

