### PR TITLE
Don't apply chambered to shotguns

### DIFF
--- a/server/src/game/weaponManager.ts
+++ b/server/src/game/weaponManager.ts
@@ -688,7 +688,7 @@ export class WeaponManager {
         const hasSplinter = this.player.hasPerk("splinter");
         const shouldApplyChambered =
             this.player.hasPerk("chambered") &&
-            itemDef.bulletCount === 1 &&
+            itemDef.ammo !== "12gauge" &&
             (weapon.ammo === 0 || //ammo count already decremented
                 weapon.ammo === this.getTrueAmmoStats(itemDef).trueMaxClip - 1);
 


### PR DESCRIPTION
Minor bug fix from [discord](https://discord.com/channels/1278403395614408725/1356783050977185955). Instead of checking if gun shoots 1 bullet, check against ammo type. This stops the usas and m1014 (super90) from having one in the chamber applied. 

I would be inclined to agree with the user that reported the bug - that one in the chamber shouldn't apply to these guns as it didn't in surviv.io, but I can't remember for sure. Obviously, if this behaviour is intended then reject this pull request.