### PR TITLE
Fix teammate pointer orientation

### DIFF
--- a/client/src/ui/ui.ts
+++ b/client/src/ui/ui.ts
@@ -845,7 +845,7 @@ export class UiManager {
                                 camAabb.min,
                                 camAabb.max,
                             )!;
-                            const rot = Math.atan2(dir.y, -dir.x) + Math.PI * 0.5;
+                            const rot = Math.atan2(dir.y, -dir.x) - Math.PI * 0.5;
                             const screenEdge = camera.m_pointToScreen(edge);
                             const onscreen = coldet.testCircleAabb(
                                 playerPos,

--- a/client/src/ui/ui.ts
+++ b/client/src/ui/ui.ts
@@ -845,6 +845,7 @@ export class UiManager {
                                 camAabb.min,
                                 camAabb.max,
                             )!;
+                            // fixme: find actual cause for the indicator rotation facing backwards
                             const rot = Math.atan2(dir.y, -dir.x) - Math.PI * 0.5;
                             const screenEdge = camera.m_pointToScreen(edge);
                             const onscreen = coldet.testCircleAabb(


### PR DESCRIPTION
Very minor bug fix from [issue on discord](https://discord.com/channels/1278403395614408725/1350470179041312880). Teammate pointer icon is rotated 180° to point back towards the player.