### PR TITLE
Fix a rare firepower bug

### DIFF
--- a/server/src/game/weaponManager.ts
+++ b/server/src/game/weaponManager.ts
@@ -449,6 +449,7 @@ export class WeaponManager {
      * called when reload action completed, actually updates all state variables
      */
     reload(curWeapIdx = this.curWeapIdx): void {
+        if (!this.weapons[curWeapIdx].type) return; // prevent rare bug
         const weapon = this.weapons[curWeapIdx];
         const weaponDef = GameObjectDefs[weapon.type] as GunDef;
         const trueAmmoStats = this.getTrueAmmoStats(weaponDef);


### PR DESCRIPTION
This one added line is intened to fix a rare bug relating to the firepower perk.

In several game modes it is possible to obtain a droppable firepower perk. When this perk is dropped, in `server/src/game/objects/player.ts:1115` it will promptly reload both guns with no checks (`server/src/game/weaponManager.ts:451`). However, if this slot is empty, then `weaponDef` will be undefined and then getting the stats will result in a TypeError on the server, which results in the current game becoming unplayable.

By adding a precondition check this bug should be resolved.