### PR TITLE
verbose logging for socket closure; log disconnectMsg to the client

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -334,7 +334,9 @@ class Application {
                 if (errMsg) {
                     this.showErrorModal(errMsg);
                 }
-
+                if (IS_DEV) {
+                    console.error("onQuit", errMsg);
+                }
                 SDK.gamePlayStop();
             };
             this.game = new Game(

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -334,9 +334,7 @@ class Application {
                 if (errMsg) {
                     this.showErrorModal(errMsg);
                 }
-                if (IS_DEV) {
-                    console.error("onQuit", errMsg);
-                }
+                console.error("Quitting", errMsg);
                 SDK.gamePlayStop();
             };
             this.game = new Game(

--- a/server/src/game/gameManager.ts
+++ b/server/src/game/gameManager.ts
@@ -158,6 +158,7 @@ export class SingleThreadGameManager implements GameManager {
         const data = socket.getUserData();
         const game = this.gamesById.get(data.gameId);
         if (game === undefined) {
+            console.log(`Game ${data.gameId} not found, closing socket.`);
             socket.close();
             return;
         }

--- a/server/src/game/gameProcessManager.ts
+++ b/server/src/game/gameProcessManager.ts
@@ -256,6 +256,7 @@ export class GameProcessManager implements GameManager {
             const data = socket.getUserData();
             if (data.closed) continue;
             if (data.gameId !== gameProc.id) continue;
+            this.logger.warn(`Closing socket for ${gameProc.id}`);
             socket.close();
         }
 
@@ -319,6 +320,7 @@ export class GameProcessManager implements GameManager {
         const data = socket.getUserData();
         const proc = this.processById.get(data.gameId);
         if (proc === undefined) {
+            this.logger.warn("prcoess not found, closing socket.");
             socket.close();
             return;
         }

--- a/server/src/gameServer.ts
+++ b/server/src/gameServer.ts
@@ -233,6 +233,7 @@ app.ws<GameSocketData>("/play", {
 
     message(socket: WebSocket<GameSocketData>, message) {
         if (gameWsRateLimit.isRateLimited(socket.getUserData().rateLimit)) {
+            server.logger.warn("Game websocket rate limited, closing socket.");
             socket.close();
             return;
         }
@@ -293,6 +294,7 @@ app.ws<pingSocketData>("/ptc", {
 
     message(socket: WebSocket<pingSocketData>, message) {
         if (pingWsRateLimit.isRateLimited(socket.getUserData().rateLimit)) {
+            server.logger.warn("Ping websocket rate limited, closing socket.");
             socket.close();
             return;
         }

--- a/server/src/teamMenu.ts
+++ b/server/src/teamMenu.ts
@@ -469,6 +469,7 @@ export class TeamMenu {
                                     },
                                 } satisfies TeamErrorMsg),
                             );
+                            teamMenu.logger.warn(`closed socket for ${closeReason}`);
                             ws.close();
                             return;
                         }
@@ -479,6 +480,7 @@ export class TeamMenu {
                         const data = ws.raw! as SocketData;
 
                         if (wsRateLimit.isRateLimited(data.rateLimit)) {
+                            teamMenu.logger.warn("Rate limited, closing socket.");
                             ws.close();
                             return;
                         }
@@ -524,6 +526,7 @@ export class TeamMenu {
             msg = JSON.parse(data);
             zTeamClientMsg.parse(msg);
         } catch {
+            this.logger.warn("Failed to parse message, closing socket.");
             ws.close();
             return;
         }
@@ -531,6 +534,7 @@ export class TeamMenu {
         const player = ws.raw?.player;
         // i really don't think this is necessary but /shrug
         if (!player) {
+            this.logger.warn("Player not found, closing socket.");
             ws.close();
             return;
         }
@@ -575,6 +579,7 @@ export class TeamMenu {
         // if we don't have a room at this point it meant both creation and joining failed
         // so close the socket
         if (!player.room) {
+            this.logger.warn("Player not in room, closing socket.");
             ws.close();
             return;
         }
@@ -587,6 +592,7 @@ export class TeamMenu {
         const player = ws.raw?.player;
 
         if (!player) {
+            this.logger.warn("Player not found, closing socket.");
             ws.close();
             return;
         }


### PR DESCRIPTION
on the client, sometimes the error default to a generic error if no translation are found before shown to the user, which makes things harder to debug

logging it to the client already helped me fix a nasty bug in production